### PR TITLE
Add generated assets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .vscode
-public/js/app.js
 public/css/app.css
+public/css/app.css.map
+public/js/app.js
+public/js/app.js.map
+public/mix-manifest.json
 todo.txt
 .php_cs.cache


### PR DESCRIPTION
This PR adds the meta files generated by `npm run prod` to `.gitignore` - we will not be tracking
them. 
