### PR TITLE
Allow drafts to be previewed without a publication date

### DIFF
--- a/resources/views/livewire/backstage/post-preview.blade.php
+++ b/resources/views/livewire/backstage/post-preview.blade.php
@@ -18,10 +18,15 @@
       <header class="pb-4">
         <h1 class="text-3xl mb-2">{{ $post->title }}</h1>
         <div class="md:flex md:justify-between md:items-center">
-          <time datetime="{{ $post->published_at->toAtomString() }}"
-                class="block mb-1 text-cool-gray-400">
+          @if ($post->hasBeenPublished())
+          <time
+            datetime="{{ $post->published_at->toAtomString() }}"
+            class="block mb-1 text-cool-gray-400">
             {{ $post->published_at->format('F j, Y') }}
           </time>
+          @else
+            <div class="mb-1 text-cool-gray-400">DRAFT</div>
+          @endif
           <div>
             @foreach($post->tags as $tag)
               <x-tag>{{ $tag->name }}</x-tag>


### PR DESCRIPTION
This PR checks to ensure a post has a publication date before attempting to display it on the post
preview page. 
