### PR TITLE
Adjust Tracking in Page Headings

### DIFF
--- a/resources/views/components/heading.blade.php
+++ b/resources/views/components/heading.blade.php
@@ -1,6 +1,6 @@
 <div {{ $attributes->merge(['class' => 'lg:flex lg:items-center lg:justify-between mb-8']) }}>
   <div class="flex-1 min-w-0">
-    <h2 class="text-2xl font-bold leading-7 text-cool-gray-300 sm:text-3xl sm:leading-9 sm:truncate">
+    <h2 class="text-2xl font-bold leading-7 tracking-wide text-cool-gray-300 sm:text-3xl sm:leading-9 sm:truncate">
       {{ $slot }}
     </h2>
     @isset($meta)

--- a/resources/views/components/page-header.blade.php
+++ b/resources/views/components/page-header.blade.php
@@ -1,5 +1,5 @@
 <div class="mb-4 w-full">
-  <h2 class="text-3xl leading-9 tracking-tight font-bold text-cool-gray-300 sm:text-4xl sm:leading-10">
+  <h2 class="text-3xl leading-9 tracking-wide font-bold text-cool-gray-300 sm:text-4xl sm:leading-10">
     {{ $slot }}
   </h2>
 </div>

--- a/resources/views/components/post.blade.php
+++ b/resources/views/components/post.blade.php
@@ -1,6 +1,5 @@
 <article class="post">
   <header class="pb-4">
-    <h1 class="text-3xl mb-2">{{ $post->title }}</h1>
     <div class="md:flex md:justify-between md:items-center">
       @if ($post->hasBeenPublished())
       <time

--- a/resources/views/livewire/backstage/post-preview.blade.php
+++ b/resources/views/livewire/backstage/post-preview.blade.php
@@ -1,6 +1,8 @@
 <div>
   <x-heading>
-    Preview: {{ $post->title }}
+    <p class="text-cool-gray-500">
+      Preview:
+    </p>
     <x-slot name="options">
       <x-button.secondary
         url="{{ route('backstage.posts.show',$post->reference_id) }}"
@@ -13,6 +15,11 @@
     <p>This post has not yet been rendered.</p>
   </x-card>
   @else
+  <div class="mb-4 w-full">
+    <h2 class="text-3xl leading-9 tracking-wide font-bold text-cool-gray-300 sm:text-4xl sm:leading-10">
+      {{ $post->title }}
+    </h2>
+  </div>
   <x-card>
     <x-post :post="$post" />
   </x-card>

--- a/resources/views/livewire/blog-post.blade.php
+++ b/resources/views/livewire/blog-post.blade.php
@@ -7,6 +7,11 @@
 @endsection
 
 <div>
+  <div class="mb-4 w-full">
+    <h2 class="text-3xl leading-9 tracking-wide font-bold text-cool-gray-300 sm:text-4xl sm:leading-10">
+      {{ $post->title }}
+    </h2>
+  </div>
   <x-card class="mb-8">
     <x-post :post="$post" />
   </x-card>


### PR DESCRIPTION
This PR adjust the various page headings on the site, increasing the spacing
between the letters a bit. I am also experimenting with a new position for the
title on blog post pages. 
