### PR TITLE
Adjust Container Width

### DIFF
--- a/resources/views/components/break-points.blade.php
+++ b/resources/views/components/break-points.blade.php
@@ -1,0 +1,9 @@
+{{-- https://github.com/stefanbauer/tailwindcss-breakpoint-detector/blob/master/resources/views/detector.blade.php --}}
+<div class="fixed bottom-0 right-0 border-2 border-white m-10 p-6 h-6 w-6 text-lg font-bold text-white uppercase shadow-md rounded-md flex items-center justify-center bg-gray-600 sm:bg-red-500 md:bg-orange-500 lg:bg-green-500 xl:bg-blue-600 2xl:bg-purple-700" style="z-index: 9999;">
+  <div class="block sm:hidden md:hidden lg:hidden xl:hidden 2xl:hidden">xs</div>
+  <div class="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">sm</div>
+  <div class="hidden sm:hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
+  <div class="hidden sm:hidden md:hidden lg:block xl:hidden 2xl:hidden">lg</div>
+  <div class="hidden sm:hidden md:hidden lg:hidden xl:block 2xl:hidden">xl</div>
+  <div class="hidden sm:hidden md:hidden lg:hidden xl:hidden 2xl:block">2xl</div>
+</div>

--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -43,5 +43,9 @@
     {{ $slot }}
     <script src="{{ url(mix('js/app.js')) }}"></script>
     @livewireScripts
+
+    @env('local')
+      <x-break-points />
+    @endenv
   </body>
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,6 +1,6 @@
 <x-layouts.base>
-  <x-header class="mb-4" />
-  <div class="container mx-auto p-4">
+  <x-header class="mb-4 lg:mb-8" />
+  <div class="container mx-auto">
 
     @if(session()->has('alerts'))
       <div class="mx-auto mb-4 -mt-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,16 @@ module.exports = {
           '800': '#27303f',
           '900': '#1a202e',
         },
-      }
+      },
+      container: {
+        padding: {
+          DEFAULT: '1rem',
+          sm: '2rem',
+          lg: '4rem',
+          xl: '5rem',
+          '2xl': '8rem',
+        },
+      },
     },
   },
   variants: {},


### PR DESCRIPTION
This PR adjust the overall container width to make it a tad bit narrower at
larger breakpoints.  The addition of the `2xl` breakpoint in Tailwind 2.0 lead
to the default container width on large monitors feeling too large for this
design.

This PR also adds a visual break point detector, as borrowed from
stefanbauer/tailwindcss-breakpoint-detector.
