### PR TITLE
Allow users to optionally view raw markdown

### DIFF
--- a/app/Actions/Posts/PostHtmlRenderingAction.php
+++ b/app/Actions/Posts/PostHtmlRenderingAction.php
@@ -12,7 +12,7 @@ use App\Utilities\Str;
 use League\CommonMark\CommonMarkConverter;
 use StageRightLabs\Actions\Action;
 
-class PostRenderingAction extends Action
+class PostHtmlRenderingAction extends Action
 {
     /**
      * @var Post

--- a/app/Actions/Posts/PostMarkdownRenderingAction.php
+++ b/app/Actions/Posts/PostMarkdownRenderingAction.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Actions\Posts;
+
+use App\Actions\Complete;
+use App\Actions\Failure;
+use App\Actions\Reaction;
+use App\Post;
+use App\Snippet;
+use App\Utilities\Arr;
+use App\Utilities\Str;
+use League\CommonMark\CommonMarkConverter;
+use StageRightLabs\Actions\Action;
+
+class PostMarkdownRenderingAction extends Action
+{
+    /**
+     * @var Post
+     */
+    public $post;
+
+    /**
+     * @var string
+     */
+    public $rendered;
+
+    /**
+     * Convert the contents of a post to html.
+     *
+     * @param Action|array $input
+     * @return self
+     */
+    public function handle($input = [])
+    {
+        $this->post = $input['post'];
+
+        if (empty($input['post']->content)) {
+            return $this->fail("Post {$input['post']->reference_id} has no content to render.");
+        }
+
+        $this->rendered = $this->replaceShortcodes(
+            $input['post']->content,
+            $input['post']->shortcodes
+        );
+
+        return $this->complete("Post {$input['post']->reference_id} content has been rendered.");
+    }
+
+    /**
+     * Replace shortcodes with their rendered output.
+     *
+     * @param string $content
+     * @param Collection $shortcodes
+     * @return string
+     */
+    protected function replaceShortcodes($content, $shortcodes)
+    {
+        return $this->fetchSnippets($shortcodes)
+            ->reduce(function ($content, $snippet) {
+                return str_replace(
+                    $snippet->shortcode,
+                    $snippet->rendered,
+                    $content
+                );
+            }, $content ?? '');
+    }
+
+    /**
+     * Fetch snippet content from the database.
+     *
+     * @param Collection $shortcodes
+     * @return Collection
+     */
+    protected function fetchSnippets($shortcodes)
+    {
+        $referenceIds = $shortcodes
+            ->filter(function ($shortcode) {
+                return Str::startsWith($shortcode['code'], 'Snippet ');
+            })->map(function ($shortcode) {
+                return Str::after($shortcode['code'], 'Snippet ');
+            });
+
+        return Snippet::whereIn('reference_id', $referenceIds)->get();
+    }
+
+    /**
+     * The input keys required by this action.
+     *
+     * @return array
+     */
+    public function required()
+    {
+        return [
+            'post'
+        ];
+    }
+}

--- a/app/Http/Controllers/MarkdownController.php
+++ b/app/Http/Controllers/MarkdownController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\Posts\PostMarkdownRenderingAction;
+use App\Post;
+use App\Utilities\Flash;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Response;
+
+class MarkdownController extends Controller
+{
+    public function show($slug)
+    {
+        $post = Post::published()
+            ->where('slug', $slug)
+            ->first();
+
+        if (!$post) {
+            abort(404);
+        }
+
+        $markdown = PostMarkdownRenderingAction::execute(['post' => $post]);
+
+        if ($markdown->failed()) {
+            Flash::error("There was a problem rendering markdown for that post.");
+        return redirect()->route('home');
+        }
+
+        // Return our markdown as plain text.
+        $response = Response::make($markdown->rendered, 200);
+        $response->header('Content-Type', 'text/plain');
+
+        return $response;
+    }
+}

--- a/app/Jobs/PostRenderingJob.php
+++ b/app/Jobs/PostRenderingJob.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Actions\Posts\PostRenderingAction;
+use App\Actions\Posts\PostHtmlRenderingAction;
 use App\Post;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -38,7 +38,7 @@ class PostRenderingJob implements ShouldQueue
      */
     public function handle()
     {
-        $rendering = PostRenderingAction::execute([
+        $rendering = PostHtmlRenderingAction::execute([
             'post' => $this->post,
         ]);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\EmailVerificationController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\DeckController;
+use App\Http\Controllers\MarkdownController;
 use App\Http\Controllers\SiteMapController;
 use App\Http\Livewire\ {
     About,
@@ -32,7 +33,9 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', BlogIndex::class)->name('home');
 Route::get('blog/topic/{topic}', BlogTopic::class)->name('blog.topic');
+Route::get('blog/{slug}.md', [MarkdownController::class, 'show'])->name('blog.markdown');
 Route::get('blog/{slug}', BlogPost::class)->name('blog.post');
+
 Route::get('about', About::class)->name('about');
 
 Route::view('decks', 'decks.index')->name('decks.index');

--- a/tests/Unit/Actions/Posts/PostHtmlRenderingActionTest.php
+++ b/tests/Unit/Actions/Posts/PostHtmlRenderingActionTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Unit\Actions\Posts;
 
-use App\Actions\Posts\PostRenderingAction;
+use App\Actions\Posts\PostHtmlRenderingAction;
 use App\Actions\Snippets\SnippetRenderingAction;
 use App\Post;
 use App\Snippet;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class PostRenderingActionTest extends TestCase
+class PostHtmlRenderingActionTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -21,7 +21,7 @@ class PostRenderingActionTest extends TestCase
             'title' => 'New Post',
         ]);
 
-        $action = PostRenderingAction::execute([
+        $action = PostHtmlRenderingAction::execute([
             'post' => $post,
         ]);
 
@@ -46,7 +46,7 @@ class PostRenderingActionTest extends TestCase
             'title' => 'New Post',
         ]);
 
-        $action = PostRenderingAction::execute([
+        $action = PostHtmlRenderingAction::execute([
             'post' => $post,
         ]);
 
@@ -62,7 +62,7 @@ class PostRenderingActionTest extends TestCase
     /** @test */
     public function it_requires_a_post()
     {
-        $action = PostRenderingAction::execute();
+        $action = PostHtmlRenderingAction::execute();
 
         $this->assertFalse($action->completed());
     }

--- a/tests/Unit/Actions/Posts/PostMarkdownRenderingActionTest.php
+++ b/tests/Unit/Actions/Posts/PostMarkdownRenderingActionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit\Actions\Posts;
+
+use App\Actions\Posts\PostHtmlRenderingAction;
+use App\Actions\Posts\PostMarkdownRenderingAction;
+use App\Actions\Snippets\SnippetRenderingAction;
+use App\Post;
+use App\Snippet;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostMarkdownRenderingActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_converts_a_post_to_markdown()
+    {
+        $post = Post::factory()->create([
+            'content' => '# New Post',
+            'title' => 'New Post',
+        ]);
+
+        $action = PostMarkdownRenderingAction::execute([
+            'post' => $post,
+        ]);
+
+        $this->assertTrue($action->completed());
+        $this->assertStringContainsString('# New Post', $action->rendered);
+    }
+
+    /** @test */
+    public function it_embeds_snippet_html_into_markdown()
+    {
+        $snippetA = Snippet::factory()->create([
+            'content' => 'this is the first snippet',
+        ]);
+        $snippetA = $this->renderSnippet($snippetA);
+        $snippetB = Snippet::factory()->create([
+            'content' => 'this is the second snippet',
+        ]);
+        $snippetB = $this->renderSnippet($snippetB);
+
+        $post = Post::factory()->create([
+            'content' => "# New Post\n\n {$snippetA->shortcode} \n\n {$snippetB->shortcode}",
+            'title' => 'New Post',
+        ]);
+
+        $action = PostMarkdownRenderingAction::execute([
+            'post' => $post,
+        ]);
+
+        $this->assertTrue($post->hasShortcode($snippetA->shortcode));
+        $this->assertTrue($post->hasShortcode($snippetB->shortcode));
+        $this->assertStringContainsString('# New Post', $action->rendered);
+        $this->assertStringNotContainsString($snippetA->shortcode, $action->rendered);
+        $this->assertStringContainsString($snippetA->rendered, $action->rendered);
+        $this->assertStringNotContainsString($snippetB->shortcode, $action->rendered);
+        $this->assertStringContainsString($snippetB->rendered, $action->rendered);
+    }
+
+    /** @test */
+    public function it_requires_a_post()
+    {
+        $action = PostMarkdownRenderingAction::execute();
+
+        $this->assertFalse($action->completed());
+    }
+
+    protected function renderSnippet($snippet)
+    {
+        $action = SnippetRenderingAction::execute([
+            'snippet' => $snippet,
+            'cascade' => false,
+        ]);
+
+        $snippet->rendered = $action->rendered;
+        $snippet->save();
+
+        return $snippet;
+    }
+}


### PR DESCRIPTION
This PR allows users to add a `.md` extension to the end of a blog post URL to
view the post as raw markdown. 
