### PR TITLE
Add redirect routing for `/blog/` and `/blog`

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', BlogIndex::class)->name('home');
+Route::redirect('/blog', '/');
 Route::get('blog/topic/{topic}', BlogTopic::class)->name('blog.topic');
 Route::get('blog/{slug}', BlogPost::class)->name('blog.post');
 Route::get('about', About::class)->name('about');


### PR DESCRIPTION
This PR adds a redirect that will prevent users from seeing a 404 if they go
directly to `/blog` or `/blog/` instead of to the home page or a specific blog
post page. 
