### PR TITLE
Fix typo

### DIFF
--- a/app/Actions/Tags/TagCreatingAction.php
+++ b/app/Actions/Tags/TagCreatingAction.php
@@ -33,7 +33,7 @@ class TagCreatingAction extends Action
             return $this->fail("The '{$name}' tag could not be created.");
         }
 
-        return $this->complete("Tag '' has been created.");
+        return $this->complete("Tag '{$name}' has been created.");
     }
 
     /**


### PR DESCRIPTION
Fix a typo in the Tag Creation action. 
