### PR TITLE
Add stack description to blog posts

### DIFF
--- a/app/Actions/Posts/PostCreatingAction.php
+++ b/app/Actions/Posts/PostCreatingAction.php
@@ -26,11 +26,12 @@ class PostCreatingAction extends Action
     {
         // Create the new post
         $this->post = Post::create([
-            'title' => $input['title'],
+            'author_id' => $input['author']->id,
             'content' => $input['content'],
             'description' => Arr::get($input, 'description'),
             'slug' => $this->generateSlug($input['title']),
-            'author_id' => $input['author']->id,
+            'stack_outline' => Arr::get($input, 'stack_outline'),
+            'title' => $input['title'],
         ]);
 
         if (! $this->post) {
@@ -94,6 +95,7 @@ class PostCreatingAction extends Action
     {
         return [
             'description', // string
+            'stack_outline', // string
             'tags', // array[string]
         ];
     }

--- a/app/Actions/Posts/PostUpdatingAction.php
+++ b/app/Actions/Posts/PostUpdatingAction.php
@@ -28,13 +28,14 @@ class PostUpdatingAction extends Action
         $this->post = $input['post'];
 
         // Update Post Attributes
-        $this->post->content = $input['content'];
-        $this->post->description = Arr::get($input, 'description');
-        $this->post->title = $input['title'];
-        $this->post->slug = Arr::get($input, 'slug', $this->post->slug);
         $this->post->author_id = Arr::has($input, 'author')
             ? $input['author']->id
             : $this->post->author_id;
+        $this->post->content = $input['content'];
+        $this->post->description = Arr::get($input, 'description');
+        $this->post->slug = Arr::get($input, 'slug', $this->post->slug);
+        $this->post->stack_outline = Arr::get($input, 'stack_outline');
+        $this->post->title = $input['title'];
 
         // Update Publication Date
         if (Arr::has($input, 'published_at')) {
@@ -104,9 +105,10 @@ class PostUpdatingAction extends Action
             'author', // User
             'content', // string
             'description', // string
-            'slug', // string
-            'tags', // array
             'published_at', // string: yyyy-mm-dd
+            'slug', // string
+            'stack_outline', // string
+            'tags', // array
         ];
     }
 

--- a/app/Http/Livewire/Backstage/PostCreate.php
+++ b/app/Http/Livewire/Backstage/PostCreate.php
@@ -35,6 +35,13 @@ class PostCreate extends Component
     public $description;
 
     /**
+     * A description of the tools used in this post.
+     *
+     * @var string
+     */
+    public $stackOutline;
+
+    /**
      * The tags selected for the post to be created.
      *
      * @var array
@@ -88,6 +95,7 @@ class PostCreate extends Component
             'author' => auth()->user(),
             'content' => $this->content,
             'description' => $this->description,
+            'stack_outline' => $this->stackOutline,
             'tags' => $this->tags,
             'title' => $this->title,
         ]);

--- a/app/Http/Livewire/Backstage/PostUpdate.php
+++ b/app/Http/Livewire/Backstage/PostUpdate.php
@@ -49,6 +49,13 @@ class PostUpdate extends Component
     public $publishedAt;
 
     /**
+     * A description of the tools used in this post.
+     *
+     * @var string
+     */
+    public $stackOutline;
+
+    /**
      * The tags selected for the post to be updated.
      *
      * @var array
@@ -87,6 +94,7 @@ class PostUpdate extends Component
         $this->publishedAt = $this->post->published_at
             ? $this->post->published_at->format('Y-m-d')
             : '';
+        $this->stackOutline = $this->post->stack_outline;
         $this->tags = $this->post->tags->pluck('slug')->toArray();
         $this->title = $this->post->title;
     }
@@ -120,9 +128,10 @@ class PostUpdate extends Component
             'content' => $this->content,
             'description' => $this->description,
             'post' => $this->post,
+            'published_at' => $this->publishedAt,
+            'stack_outline' => $this->stackOutline,
             'tags' => $this->tags,
             'title' => $this->title,
-            'published_at' => $this->publishedAt,
         ]);
 
         if ($action->failed()) {

--- a/app/View/Components/Markdown.php
+++ b/app/View/Components/Markdown.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use League\CommonMark\CommonMarkConverter;
+
+/**
+ * Inspired by the Blade UI Kit
+ * https://blade-ui-kit.com/docs/0.x/markdown
+ */
+class Markdown extends Component
+{
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|string
+     */
+    public function render()
+    {
+        return view('components.markdown');
+    }
+
+    /**
+     * Convert markdown content to HTML.
+     *
+     * @param string $markdown
+     * @return string
+     */
+    public function toHtml(string $markdown)
+    {
+        return (new CommonMarkConverter())->convertToHtml($markdown);
+    }
+}

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -29,6 +29,7 @@ class PostFactory extends Factory
             'description' => $this->faker->words(6, true),
             'published_at' => null,
             'slug' => Str::slug($this->faker->sentence()),
+            'stack_outline' => $this->faker->optional()->paragraph(),
             'title' => $this->faker->sentence(),
         ];
     }

--- a/database/migrations/2021_03_13_140512_add_stack_outline_to_posts.php
+++ b/database/migrations/2021_03_13_140512_add_stack_outline_to_posts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStackOutlineToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->text('stack_outline')->nullable()->after('rendered');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('stack_outline');
+        });
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -139,3 +139,11 @@ article.post .content blockquote p {
 .author p a:hover {
     @apply text-cool-gray-200;
 }
+
+.stack-outline ul {
+    @apply mb-4 list-disc list-inside;
+}
+
+.stack-outline ol li, .stack-outline ul li {
+    @apply mb-1;
+}

--- a/resources/views/components/markdown.blade.php
+++ b/resources/views/components/markdown.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes }}>
+  {!! $toHtml($slot) !!}
+</div>

--- a/resources/views/livewire/backstage/post-create.blade.php
+++ b/resources/views/livewire/backstage/post-create.blade.php
@@ -60,6 +60,15 @@
         wrapper="mt-4"
       />
 
+      <x-form.textarea
+        class="resize-y font-mono"
+        label="Stack Outline"
+        :error="$errors->first('stackOutline')"
+        rows="5"
+        wire:model.lazy="stackOutline"
+        wrapper="mt-4"
+      />
+
       <div class="flex justify-center mt-4">
         <x-button.primary type="submit">Save</x-button.primary>
       </div>

--- a/resources/views/livewire/backstage/post-preview.blade.php
+++ b/resources/views/livewire/backstage/post-preview.blade.php
@@ -24,6 +24,13 @@
     <x-card class="mb-8 col-span-1 xl:col-span-10">
       <x-post :post="$post" />
     </x-card>
+    @if ($post->stack_outline)
+    <x-card class="mb-8 col-span-1 xl:col-span-10" heading="Tools Referenced In This Post">
+      <div class="my-2 mx-2 stack-outline">
+        <x-markdown>{{ $post->stack_outline }}</x-markdown>
+      </div>
+    </x-card>
+    @endif
     <aside class="col-span-1 xl:col-span-2 row-start-1 xl:row-start-auto lg:px-2 text-cool-gray-600 grid grid-flow-col-dense grid-cols-2 xl:grid-cols-none gap-4 xl:block">
       <div class="flex justify-end xl:block grid-cols-1 col-start-2">
         <ul class="mt-1 xl:mt-0">

--- a/resources/views/livewire/backstage/post-show.blade.php
+++ b/resources/views/livewire/backstage/post-show.blade.php
@@ -43,10 +43,14 @@
         @endif
       </x-description>
       <x-description class="sm:col-span-1" label="URL">{{ $post->url }}</x-description>
-
     </x-description-list>
   </x-card>
   <x-card heading="Content">
     <div class="p-4 whitespace-pre-wrap font-mono">{{ $post->content }}</div>
   </x-card>
+  @if ($post->stack_outline)
+  <x-card heading="Stack Outline" class="mt-8">
+    <div class="p-4 whitespace-pre-wrap font-mono">{{ $post->stack_outline }}</div>
+  </x-card>
+  @endif
 </div>

--- a/resources/views/livewire/backstage/post-update.blade.php
+++ b/resources/views/livewire/backstage/post-update.blade.php
@@ -72,6 +72,15 @@
         wrapper="mt-4"
       />
 
+      <x-form.textarea
+        class="resize-y font-mono"
+        label="Stack Outline"
+        :error="$errors->first('stackOutline')"
+        rows="5"
+        wire:model.lazy="stackOutline"
+        wrapper="mt-4"
+      />
+
       <div class="flex justify-center mt-4">
         <x-button.primary type="submit">Save</x-button.primary>
       </div>

--- a/resources/views/livewire/blog-post.blade.php
+++ b/resources/views/livewire/blog-post.blade.php
@@ -13,9 +13,18 @@
     </h2>
   </div>
   <div class="grid grid-cols-1 xl:grid-cols-12 gap-2 xl:gap-4 ">
-    <x-card class="mb-8 col-span-1 xl:col-span-10">
-      <x-post :post="$post" />
-    </x-card>
+    <div class="col-span-1 xl:col-span-10">
+      <x-card class="mb-8">
+        <x-post :post="$post" />
+      </x-card>
+      @if($post->stack_outline)
+        <x-card class="mb-8 col-span-1 xl:col-span-10" heading="Tools Referenced In This Post">
+          <div class="my-2 mx-2 stack-outline">
+            <x-markdown>{{ $post->stack_outline }}</x-markdown>
+          </div>
+        </x-card>
+      @endif
+    </div>
     <aside class="col-span-1 xl:col-span-2 row-start-1 xl:row-start-auto lg:px-2 text-cool-gray-600 grid grid-flow-col-dense grid-cols-2 xl:grid-cols-none gap-4 xl:block">
       <div class="flex justify-end xl:block grid-cols-1 col-start-2">
         <ul class="mt-1 xl:mt-0">

--- a/tests/Feature/Backstage/PostCreationTest.php
+++ b/tests/Feature/Backstage/PostCreationTest.php
@@ -29,6 +29,7 @@ class PostCreationTest extends TestCase
         Livewire::test(PostCreate::class)
             ->set('content', "This is the new\npost content.")
             ->set('description', 'This is a post description')
+            ->set('stackOutline', 'This is a stack outline')
             ->set('title', 'A New Post')
             ->call('store');
 
@@ -36,6 +37,7 @@ class PostCreationTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'content' => "This is the new\npost content.",
             'description' => 'This is a post description',
+            'stack_outline' => 'This is a stack outline',
             'title' => 'A New Post',
         ]);
     }

--- a/tests/Feature/Backstage/PostUpdatingTest.php
+++ b/tests/Feature/Backstage/PostUpdatingTest.php
@@ -30,19 +30,22 @@ class PostUpdatingTest extends TestCase
         $post = Post::factory()->create([
             'content' => 'Original content',
             'description' => 'Original description',
+            'stack_outline' => 'Original stack outline',
             'title' => 'Original Title',
         ]);
 
         Livewire::test(PostUpdate::class, ['ref' => $post->reference_id])
             ->set('content', 'New content')
             ->set('description', 'New description')
+            ->set('stackOutline', 'New stack outline')
             ->set('title', 'New Title')
             ->call('update');
 
         $this->assertDatabaseHas('posts', [
-            'reference_id' => $post->reference_id,
             'content' => 'New content',
             'description' => 'New description',
+            'reference_id' => $post->reference_id,
+            'stack_outline' => 'New stack outline',
             'title' => 'New Title',
         ]);
     }

--- a/tests/Unit/Actions/Posts/PostCreatingActionTest.php
+++ b/tests/Unit/Actions/Posts/PostCreatingActionTest.php
@@ -21,6 +21,7 @@ class PostCreatingActionTest extends TestCase
             'author' => $author,
             'content' => 'Some new content',
             'description' => 'Some description',
+            'stack_outline' => 'Some stack outline',
             'title' => 'A New Post',
         ]);
 
@@ -28,6 +29,7 @@ class PostCreatingActionTest extends TestCase
         $this->assertEquals('A New Post', $action->post->title);
         $this->assertEquals('a-new-post', $action->post->slug);
         $this->assertEquals('Some description', $action->post->description);
+        $this->assertEquals('Some stack outline', $action->post->stack_outline);
         $this->assertNull($action->post->published_at);
         $this->assertEquals($author->id, $action->post->author_id);
     }

--- a/tests/Unit/Actions/Posts/PostUpdatingActionTest.php
+++ b/tests/Unit/Actions/Posts/PostUpdatingActionTest.php
@@ -20,8 +20,9 @@ class PostUpdatingActionTest extends TestCase
         $post = Post::factory()->create([
             'content' => 'Original Content',
             'description' => 'Original Description',
-            'title' => 'Original Title',
             'slug' => 'original-title',
+            'stack_outline' => 'Original stack outline',
+            'title' => 'Original Title',
         ]);
 
         $action = PostUpdatingAction::execute([
@@ -29,6 +30,7 @@ class PostUpdatingActionTest extends TestCase
             'content' => 'New Content',
             'description' => 'New Description',
             'post' => $post,
+            'stack_outline' => 'New stack outline',
             'title' => 'New Title',
         ]);
 
@@ -36,6 +38,7 @@ class PostUpdatingActionTest extends TestCase
         $this->assertEquals('New Content', $action->post->content);
         $this->assertEquals('New Description', $action->post->description);
         $this->assertEquals('original-title', $action->post->slug);
+        $this->assertEquals('New stack outline', $action->post->stack_outline);
         $this->assertEquals('New Title', $action->post->title);
     }
 


### PR DESCRIPTION
This PR adds a 'stack outline' to blog posts; this will allow me to highlight
the tools used in any given post as a separate callout on the page.
