### PR TITLE
Make precommit script executable and apply code formatting

### DIFF
--- a/app/Http/Livewire/Backstage/PostShow.php
+++ b/app/Http/Livewire/Backstage/PostShow.php
@@ -9,7 +9,6 @@ use App\Http\Livewire\DisplaysAlerts;
 use App\Post;
 use App\Series;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Collection;
 use Livewire\Component;
 
 class PostShow extends Component
@@ -94,8 +93,9 @@ class PostShow extends Component
      */
     public function addSeries()
     {
-        if (!$series = Series::find($this->seriesIdToAdd)) {
+        if (! $series = Series::find($this->seriesIdToAdd)) {
             $this->alert('Invalid series selected.', 'error');
+
             return;
         }
 
@@ -122,7 +122,7 @@ class PostShow extends Component
      */
     public function removeSeries($series)
     {
-        if (!$series = Series::find($series)) {
+        if (! $series = Series::find($series)) {
             return;
         }
 

--- a/app/Http/Livewire/Backstage/SeriesIndex.php
+++ b/app/Http/Livewire/Backstage/SeriesIndex.php
@@ -29,7 +29,7 @@ class SeriesIndex extends Component
     public function render()
     {
         return view('livewire.backstage.series-index', [
-            'series' => Series::orderByDesc('created_at')->paginate()
+            'series' => Series::orderByDesc('created_at')->paginate(),
         ]);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -4,7 +4,6 @@ namespace App;
 
 use App\Concerns\ReferenceIds;
 use App\Concerns\UuidAsPrimaryKey;
-use App\Series;
 use App\Utilities\Str;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/app/View/Components/Markdown.php
+++ b/app/View/Components/Markdown.php
@@ -7,7 +7,7 @@ use League\CommonMark\CommonMarkConverter;
 
 /**
  * Inspired by the Blade UI Kit
- * https://blade-ui-kit.com/docs/0.x/markdown
+ * https://blade-ui-kit.com/docs/0.x/markdown.
  */
 class Markdown extends Component
 {

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -8,6 +8,8 @@
 
 CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.php')
 
+echo CHANGED_FILES;
+
 if [ -n "$CHANGED_FILES" ]; then
 
     docker run --rm \

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -8,8 +8,6 @@
 
 CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.php')
 
-echo CHANGED_FILES;
-
 if [ -n "$CHANGED_FILES" ]; then
 
     docker run --rm \

--- a/tests/Feature/Backstage/SeriesCreationTest.php
+++ b/tests/Feature/Backstage/SeriesCreationTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Backstage;
 use App\Http\Livewire\Backstage\SeriesCreate;
 use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/tests/Feature/Backstage/SeriesRemovalTest.php
+++ b/tests/Feature/Backstage/SeriesRemovalTest.php
@@ -7,7 +7,6 @@ use App\Post;
 use App\Series;
 use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Livewire\Livewire;
 use Tests\TestCase;
 


### PR DESCRIPTION
In #104 I forgot to make the `precommit.sh` script executable.  This PR fixes that, and applies code formatting changes that were previously missed.
