### PR TITLE
Fix some typos in our 'series' templates.

### DIFF
--- a/resources/views/components/part-of-a-series.blade.php
+++ b/resources/views/components/part-of-a-series.blade.php
@@ -5,7 +5,7 @@
 
 @if ($series && $series->publishedPosts->count() > 1)
 <x-card {{ $attributes->merge(['class' => 'mb-8'])}} :heading="$series->name">
-  <p class="text-lg mb-4">{{ $series->name }}</p>
+  <p class="text-lg mb-4">{{ $series->description }}</p>
   <ol class="list-decimal list-inside">
   @foreach ($series->publishedPosts as $link)
     <li class="my-1 text-lg">

--- a/resources/views/livewire/backstage/series-create.blade.php
+++ b/resources/views/livewire/backstage/series-create.blade.php
@@ -25,7 +25,7 @@
 
     <x-form.textarea
       class="resize-y font-mono"
-      label="Content"
+      label="Description"
       :error="$errors->first('description')"
       rows="5"
       wire:model.lazy="description"

--- a/resources/views/livewire/backstage/series-update.blade.php
+++ b/resources/views/livewire/backstage/series-update.blade.php
@@ -34,7 +34,7 @@
 
     <x-form.textarea
       class="resize-y font-mono"
-      label="Content"
+      label="Description"
       :error="$errors->first('series.description')"
       rows="5"
       wire:model.lazy="series.description"


### PR DESCRIPTION
This PR addresses some small typos in the templates created for viewing 'series' information.
