### PR TITLE
Switch the the Alpine js CSP build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
         "vite": "^6.0"
     },
     "dependencies": {
-        "alpinejs": "^3.14.6"
+        "@alpinejs/csp": "^3.14.7"
     }
 }

--- a/resources/app.js
+++ b/resources/app.js
@@ -1,4 +1,4 @@
-import Alpine from 'alpinejs'
+import Alpine from '@alpinejs/csp'
 
 // https://inspiredwebdev.com/copy-to-clipboard-with-javascript
 window.copyToClipboard = function (text) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@alpinejs/csp@^3.14.7":
+  version "3.14.7"
+  resolved "https://registry.yarnpkg.com/@alpinejs/csp/-/csp-3.14.7.tgz#94dd672915618ff2c128f81b32dc6e0b84ed0c0c"
+  integrity sha512-9f3a9FLl9a7Kont2zkMgMAHmi0APO7uk1EiqZGKy2jMExQhJZirCHGuw4wq4NDZJ5p6HAGOuzg6nPWR1DrLzdQ==
+  dependencies:
+    "@vue/reactivity" "~3.1.1"
+
 "@esbuild/aix-ppc64@0.24.0":
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz#b57697945b50e99007b4c2521507dc613d4a648c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,13 +321,6 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.1.5.tgz#74ee3aad995d0a3996a6bb9533d4d280514ede03"
   integrity sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==
 
-alpinejs@^3.14.6:
-  version "3.14.6"
-  resolved "https://registry.yarnpkg.com/alpinejs/-/alpinejs-3.14.6.tgz#3eb54aeccfed91a7d91a4eb7fa35f03bedd65743"
-  integrity sha512-8Abdd6u8oVurOChPqWCHS2Lr3C9g4+zb/kL1vNPykK/2dVkb3giTcpQ1wykzzWmX7wbTvWLnHX3I3CPPnnAMCA==
-  dependencies:
-    "@vue/reactivity" "~3.1.1"
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"


### PR DESCRIPTION
This PR removes the regular Alpine.js package and replaces it with the CSP build.