### PR TITLE
Add 'require-trusted-types' to CSP

### DIFF
--- a/app/Http/Middleware/SetSecurityHeaders.php
+++ b/app/Http/Middleware/SetSecurityHeaders.php
@@ -38,7 +38,7 @@ class SetSecurityHeaders
         // https://scotthelme.co.uk/content-security-policy-an-introduction/
         $response->headers->set(
             'Content-Security-Policy',
-            "default-src 'self'; script-src: 'nonce-".Vite::cspNonce()."' 'strict-dynamic'",
+            "script-src 'nonce-".Vite::cspNonce()."' 'strict-dynamic'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script';",
             $replace = true,
         );
 


### PR DESCRIPTION
This PR tweaks the CSP yet again, this time removing default-src and adding require-trusted-types-for.