### PR TITLE
Add prettier for formatting blade, tailwind and JS

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+    "plugins": ["prettier-plugin-blade", "prettier-plugin-tailwindcss"],
+    "overrides": [
+      {
+        "files": [
+          "*.blade.php"
+        ],
+        "options": {
+          "parser": "blade"
+        }
+      }
+    ]
+  }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
         "autoprefixer": "^10.4.20",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.4.47",
+        "prettier": "^3.4.2",
+        "prettier-plugin-blade": "^2",
+        "prettier-plugin-tailwindcss": "^0.6.9",
         "tailwindcss": "^3.4.14",
         "vite": "^6.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,21 @@ postcss@^8.4.47, postcss@^8.4.49:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+prettier-plugin-blade@^2:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-blade/-/prettier-plugin-blade-2.1.19.tgz#9c2105a9bed08b20a39bab8c54d5fbf725a54d91"
+  integrity sha512-bLOrrZmWYZe9IN0EkMUESgOLExCKGJYOgUr+ZOxaOujUK0rirxTPiUYI4wnDZZfX2sI9MHaHCeKTlRnNmiRhAQ==
+
+prettier-plugin-tailwindcss@^0.6.9:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz#db84c32918eae9b44e5a5f0aa4d1249cc39fa739"
+  integrity sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==
+
+prettier@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
+  integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"


### PR DESCRIPTION
This PR adds prettier for automatic formatting of blade files, Tailwind and JS.  This implementation come's from Matt Stauffer's blog post: https://mattstauffer.com/blog/how-to-set-up-prettier-on-a-laravel-app-to-lint-tailwind-class-order-and-more/.