### PR TITLE
Add signal trapping and entry point to PHP container

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -35,11 +35,14 @@ COPY xdebug.ini /usr/local/etc/php/conf.d
 # Clean up apk dependencies
 RUN apk del build-deps
 
+# Copy utility scripts into the container
+COPY start.sh /usr/local/bin/
+
 # Set the active user
 USER ${NAME}
 
 # Set the active directory
 WORKDIR /var/www
 
-# Serve the web application through the PHP dev server
-CMD ["php", "artisan", "serve", "--host", "0.0.0.0"]
+# Set the entry point as the default command
+CMD ["/usr/local/bin/start.sh"]

--- a/docker/php/start.sh
+++ b/docker/php/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Start processes
+echo "Starting services..."
+php -d display_errors=1 -d error_reporting=E_ALL artisan serve --host 0.0.0.0 --no-ansi -vvv &
+#php /usr/local/bin/watch.php &
+
+# Wait for any child to exit or signal
+trap  "exit" SIGTERM SIGINT SIGQUIT TERM; while true; do sleep 1; done


### PR DESCRIPTION
This PR adds an entrypoint script to the PHP container, as well as adding signal traps to speed up the process of shuttind down the containers with `docker compose down`.
